### PR TITLE
[BUGFIX] Ordena colaboradores por ordem alfabetica na area "Pontuar Colaborador"

### DIFF
--- a/app/Http/Controllers/PointController.php
+++ b/app/Http/Controllers/PointController.php
@@ -25,7 +25,7 @@ class PointController extends Controller
     public function create(){
 
         $badges = Badge::all();
-        $users = User::all();
+        $users = User::all()->sortBy('name', SORT_ASC);
 
         return view('point.create', ['badges' => $badges, 'users' => $users]);
     }

--- a/app/Http/Controllers/PointController.php
+++ b/app/Http/Controllers/PointController.php
@@ -25,7 +25,7 @@ class PointController extends Controller
     public function create(){
 
         $badges = Badge::all();
-        $users = User::all()->sortBy('name', SORT_ASC);
+        $users = User::all()->sortBy('name');
 
         return view('point.create', ['badges' => $badges, 'users' => $users]);
     }


### PR DESCRIPTION
Os colaboradores não estavam vindo em ordem alfabética correta na lista da área "Pontuar Colaborador", estavam ordenados por ID.